### PR TITLE
#166335718 Implement user view all unsold car with price range

### DIFF
--- a/server/src/controllers/carController.js
+++ b/server/src/controllers/carController.js
@@ -39,8 +39,27 @@ export default class CarController {
 
   static getCars(req, res, next) {
     try {
-      const response = CarService.fetchCars(req.query.status);
-      return res.status(response.status).send(response);
+      const queryLength = Object.keys(req.query).length;
+      if (queryLength >= 0) {
+        let response;
+        switch (queryLength) {
+          case 1:
+            response = CarService.fetchCars(req.query);
+            return res.status(response.status).send(response);
+          case 3:
+            response = CarService.fetchCarWithOptions(req.query);
+            return res.status(response.status).send(response);
+          default:
+            return res.status(403).json({
+              status: 403,
+              error: 'Invalid input. Provide appropriate option',
+              success: false
+            });
+        }
+      }
+      return res
+        .status(403)
+        .json({ status: 403, error: 'Invalid input. Provide appropriate option', success: false });
     } catch (ex) {
       return next(ex);
     }

--- a/server/src/helpers/helpers.js
+++ b/server/src/helpers/helpers.js
@@ -130,4 +130,18 @@ export default class Helper {
     if (pattern.test(value) === true) return true;
     return false;
   }
+
+  static validateUnsoldCarWithOptions(options) {
+    const schema = {
+      status: Joi.string(),
+      min_price: Joi.number()
+        .positive()
+        .required(),
+      max_price: Joi.number()
+        .positive()
+        .required()
+    };
+
+    return Joi.validate(options, schema);
+  }
 }

--- a/server/src/models/dummydata.js
+++ b/server/src/models/dummydata.js
@@ -52,6 +52,20 @@ const storage = {
       imageId: 'showcase',
       imageUrl:
         'https://res.cloudinary.com/an-apluss/image/upload/v1558788050/AutoMart/showcase.jpg'
+    },
+    {
+      id: 4,
+      owner: 1,
+      created_on: '2019/05/25/ 13:30:30',
+      state: 'new',
+      status: 'available',
+      price: '2500000.00',
+      manufacturer: 'bmw',
+      model: 'BMW 3 Series 320d 2017',
+      body_type: 'car',
+      imageId: 'showcase',
+      imageUrl:
+        'https://res.cloudinary.com/an-apluss/image/upload/v1558788050/AutoMart/showcase.jpg'
     }
   ]
 };

--- a/server/src/services/carService.js
+++ b/server/src/services/carService.js
@@ -3,7 +3,7 @@ import storage from '../models/dummydata';
 import Car from '../models/carModel';
 import UserService from './userService';
 
-const { generateId, cloudinaryUpload } = Helper;
+const { generateId, cloudinaryUpload, validateUnsoldCarWithOptions } = Helper;
 const { cars } = storage;
 
 export default class CarService {
@@ -52,12 +52,12 @@ export default class CarService {
     };
   }
 
-  static updateCarStatus(id, newStatus) {
-    const carExist = cars.find(car => car.id === parseInt(id, 10));
+  static updateCarStatus(carId, newStatus) {
+    const carExist = cars.find(car => car.id === parseInt(carId, 10));
     if (!carExist) return { status: 403, error: 'Car id does not exist', success: false };
-    const { email } = UserService.findUserById(carExist.id);
+    const { email } = UserService.findUserById(carExist.owner);
     carExist.status = newStatus;
-    const { created_on, manufacturer, model, price, state, status } = carExist;
+    const { id, created_on, manufacturer, model, price, state, status } = carExist;
     return {
       status: 202,
       data: {
@@ -74,12 +74,12 @@ export default class CarService {
     };
   }
 
-  static updateCarPrice(id, newPrice) {
-    const carExist = cars.find(car => car.id === parseInt(id, 10));
+  static updateCarPrice(carId, newPrice) {
+    const carExist = cars.find(car => car.id === parseInt(carId, 10));
     if (!carExist) return { status: 403, error: 'Car id does not exist', success: false };
-    const { email } = UserService.findUserById(carExist.id);
+    const { email } = UserService.findUserById(carExist.owner);
     carExist.price = parseFloat(newPrice).toFixed(2);
-    const { created_on, manufacturer, model, price, state, status } = carExist;
+    const { id, created_on, manufacturer, model, price, state, status } = carExist;
     return {
       status: 202,
       data: {
@@ -129,9 +129,15 @@ export default class CarService {
     };
   }
 
-  static fetchCars(status) {
+  static fetchCars(carString) {
+    const { status } = carString;
+
+    if (typeof status === 'undefined') {
+      return { status: 403, error: 'Status is not provided', success: false };
+    }
+
     if (status !== 'available') {
-      return { status: 403, error: `Status can only be 'available'`, success: false };
+      return { status: 403, error: 'Status can only be available', success: false };
     }
 
     const carExists = cars.filter(car => car.status === status);
@@ -155,5 +161,54 @@ export default class CarService {
     }
 
     return { status: 200, data: 'No car is available for sale', success: true };
+  }
+
+  static fetchCarWithOptions(options) {
+    const { status, min_price, max_price } = options;
+
+    if (typeof status === 'undefined')
+      return { status: 403, error: 'Status is not provided', success: false };
+
+    if (status !== 'available')
+      return { status: 403, error: 'Status can only be available', success: false };
+
+    if (parseFloat(min_price) >= parseFloat(max_price))
+      return { status: 403, error: 'max_price must be greater min_price', success: false };
+
+    const { error } = validateUnsoldCarWithOptions(options);
+    if (error) return { status: 403, error: error.details[0].message, success: false };
+
+    const carExists = cars.filter(
+      car =>
+        car.status === status &&
+        (parseFloat(car.price) >= parseFloat(min_price) &&
+          parseFloat(car.price) <= parseFloat(max_price))
+    );
+
+    let data;
+    if (carExists) {
+      data = carExists.map(carExist => {
+        const mappedresult = {
+          id: carExist.id,
+          owner: carExist.owner,
+          created_on: carExist.created_on,
+          state: carExist.state,
+          status: carExist.status,
+          price: carExist.price,
+          manufacturer: carExist.manufacturer,
+          model: carExist.model,
+          body_type: carExist.body_type
+        };
+
+        return mappedresult;
+      });
+    }
+    if (data.length > 0) return { status: 200, data, success: true };
+
+    return {
+      status: 200,
+      data: `Car within the between ${min_price} and ${max_price} are currently unavailable`,
+      success: true
+    };
   }
 }

--- a/server/src/tests/car.test.js
+++ b/server/src/tests/car.test.js
@@ -585,6 +585,18 @@ describe('Test Suite For Car Endpoints', () => {
           done();
         });
     });
+    it('should return message if car status that read available is not on the platform', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?status=available')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'data');
+          res.body.status.should.be.eql(200);
+          res.body.success.should.be.eql(true);
+          done();
+        });
+    });
     it('should return error if status is empty', done => {
       chai
         .request(server)
@@ -634,19 +646,6 @@ describe('Test Suite For Car Endpoints', () => {
           done();
         });
     });
-    it("should return message if car Ad which status value reads available between the range of specific prices doesn't exist", done => {
-      chai
-        .request(server)
-        .get('/api/v1/car?status=available&min_price=1700000&max_price=1900000')
-        .end((er, res) => {
-          res.body.should.be.an('object');
-          res.body.should.have.keys('status', 'success', 'data');
-          res.body.status.should.be.eql(200);
-          res.body.success.should.be.eql(true);
-          res.body.data.should.be.eql('Car within the specified range cannot be found');
-          done();
-        });
-    });
     it('should return error if provided value for min_price is non-numeric', done => {
       chai
         .request(server)
@@ -654,7 +653,7 @@ describe('Test Suite For Car Endpoints', () => {
         .end((er, res) => {
           res.body.should.be.an('object');
           res.body.should.have.keys('status', 'success', 'error');
-          res.body.status.should.be.eql(422);
+          res.body.status.should.be.eql(403);
           res.body.success.should.be.eql(false);
           done();
         });
@@ -666,7 +665,7 @@ describe('Test Suite For Car Endpoints', () => {
         .end((er, res) => {
           res.body.should.be.an('object');
           res.body.should.have.keys('status', 'success', 'error');
-          res.body.status.should.be.eql(422);
+          res.body.status.should.be.eql(403);
           res.body.success.should.be.eql(false);
           done();
         });
@@ -678,7 +677,7 @@ describe('Test Suite For Car Endpoints', () => {
         .end((er, res) => {
           res.body.should.be.an('object');
           res.body.should.have.keys('status', 'success', 'error');
-          res.body.status.should.be.eql(422);
+          res.body.status.should.be.eql(403);
           res.body.success.should.be.eql(false);
           done();
         });
@@ -690,7 +689,7 @@ describe('Test Suite For Car Endpoints', () => {
         .end((er, res) => {
           res.body.should.be.an('object');
           res.body.should.have.keys('status', 'success', 'error');
-          res.body.status.should.be.eql(422);
+          res.body.status.should.be.eql(403);
           res.body.success.should.be.eql(false);
           done();
         });
@@ -702,7 +701,19 @@ describe('Test Suite For Car Endpoints', () => {
         .end((er, res) => {
           res.body.should.be.an('object');
           res.body.should.have.keys('status', 'success', 'error');
-          res.body.status.should.be.eql(422);
+          res.body.status.should.be.eql(403);
+          res.body.success.should.be.eql(false);
+          done();
+        });
+    });
+    it('should return error if provided value for min_price is greater or equal to max_price', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?status=available&min_price=1900000&max_price=1700000')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'error');
+          res.body.status.should.be.eql(403);
           res.body.success.should.be.eql(false);
           done();
         });


### PR DESCRIPTION
#### What does this PR do?
- Implement `GET  /api/v1/car?status=available&min_price==XXXValue&max_price=XXXValue` endpoint functionality

#### Description of Task to be completed?
- refactor car dummy data
- refactor car test suite
- create a validation method in helper class to validate query string
- create and refactor methods in car controller and service class

#### How should this be manually tested?
- Clone the repository using `git clone https://github.com/an-apluss/AutoMart.git` . in your terminal
- run `npm install` on your terminal
- run `npm start` to start up the server
- make a `GET`  request to the endpoint `/api/v1/car?status=available&min_price=1500000&max_price=2500000` on postman 
- You should see the below response
````
{
    "status": 200,
    "data": [
       {
            "id": 1,
            "owner": 1,
            "created_on": "2019/05/25/ 13:30:30",
            "state": "used",
            "status": "available",
            "price": "1759999.99",
            "manufacturer": "bwm",
            "model": "BMW 3 Series 320d 2014",
            "body_type": "car"
        },
        {
            "id": 2,
            "owner": 1,
            "created_on": "2019/05/25/ 13:30:30",
            "state": "new",
            "status": "available",
            "price": "2000000.00",
            "manufacturer": "bmw",
            "model": "BMW 3 Series 320d 2015",
            "body_type": "car"
        },
       ...
    ],
    "success": true
}
````

#### Any background context you want to provide?
Create environment variables file i.e `.env` in the project root directory and include below variable
- `JWTPRIVATEKEY= yourjwtprivatekey`
- `CLOUD_NAME=cloudinary_name`
-  `API_ID=cloudinary_api_key`
- `API_SECRET=cloudinary_api_secret`

#### What are the relevant pivotal tracker stories?
- PT Story link - ( [166335718](https://www.pivotaltracker.com/story/show/166335718) )

#### Screenshots(if appropriate)
-N/A
