### PR TITLE
#166438826 Implement user view all unsold which state reads new

### DIFF
--- a/server/src/controllers/carController.js
+++ b/server/src/controllers/carController.js
@@ -49,6 +49,9 @@ export default class CarController {
           case 1:
             response = CarService.fetchCars(req.query);
             return res.status(response.status).send(response);
+          case 2:
+            response = CarService.fetchCarWithState(req.query);
+            return res.status(response.status).send(response);
           case 3:
             response = CarService.fetchCarWithOptions(req.query);
             return res.status(response.status).send(response);

--- a/server/src/services/carService.js
+++ b/server/src/services/carService.js
@@ -251,4 +251,44 @@ export default class CarService {
     if (carExist) return carExist;
     return false;
   }
+
+  static fetchCarWithState(paramsData) {
+    const { status, state } = paramsData;
+
+    if (typeof status === 'undefined')
+      return { status: 403, error: 'Status is required', success: false };
+
+    if (status !== 'available')
+      return { status: 403, error: 'Status can only be available', success: false };
+
+    if (typeof state === 'undefined')
+      return { status: 403, error: 'State is required', success: false };
+
+    if (state !== 'new') return { status: 403, error: 'State can only be new', success: false };
+
+    const carExists = cars.filter(car => car.status === status && car.state === state);
+
+    let data;
+    if (carExists) {
+      data = carExists.map(carExist => {
+        const mappedresult = {
+          id: carExist.id,
+          owner: carExist.owner,
+          created_on: carExist.created_on,
+          state: carExist.state,
+          status: carExist.status,
+          price: carExist.price,
+          manufacturer: carExist.manufacturer,
+          model: carExist.model,
+          body_type: carExist.body_type
+        };
+
+        return mappedresult;
+      });
+    }
+
+    if (data.length > 0) return { status: 200, data, success: true };
+
+    return { status: 200, error: `No ${state} car is for sale`, success: true };
+  }
 }

--- a/server/src/tests/car.test.js
+++ b/server/src/tests/car.test.js
@@ -831,6 +831,54 @@ describe('Test Suite For Car Endpoints', () => {
           done();
         });
     });
+    it('should error if status is not available', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?status=randomalphabelt&state=new')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'error');
+          res.body.status.should.be.eql(403);
+          res.body.success.should.be.eql(false);
+          done();
+        });
+    });
+    it('should error if status is not undefined', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?month=jun&state=new')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'error');
+          res.body.status.should.be.eql(403);
+          res.body.success.should.be.eql(false);
+          done();
+        });
+    });
+    it('should error if state is not new', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?status=available&state=randomalphabelt')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'error');
+          res.body.status.should.be.eql(403);
+          res.body.success.should.be.eql(false);
+          done();
+        });
+    });
+    it('should error if state is not undefined', done => {
+      chai
+        .request(server)
+        .get('/api/v1/car?status=available&days=monday')
+        .end((er, res) => {
+          res.body.should.be.an('object');
+          res.body.should.have.keys('status', 'success', 'error');
+          res.body.status.should.be.eql(403);
+          res.body.success.should.be.eql(false);
+          done();
+        });
+    });
   });
   describe('GET /api/v1/car?status=available&state=used', () => {
     it('should view all cars Ad that is unsold and used', done => {


### PR DESCRIPTION
#### What does this PR do?
- Implement `GET /api/v1/car?status=available&state=new` endpoint functionality

#### Description of Task to be completed?
- refactor car test suite to increase coverage
- refactor a method in the car controller class
- create a method in car service class to handle GET /api/v1/car?status=available&state=new functionality
- delivers[#166438826]
#### How should this be manually tested?
- Clone the repository using `git clone https://github.com/an-apluss/AutoMart.git` . in your terminal
- run `npm install` on your terminal
- run `npm start` to start up the server
- make a `GET`  request to the endpoint `/api/v1/car?status=available&state=new` on postman  

- You should see the below response
````
{
    "status": 200,
    "data": [
        {
            "id": 2,
            "owner": 1,
            "created_on": "2019/05/25/ 13:30:30",
            "state": "new",
            "status": "available",
            "price": "2000000.00",
            "manufacturer": "bmw",
            "model": "BMW 3 Series 320d 2015",
            "body_type": "car"
        },
        {
            "id": 4,
            "owner": 1,
            "created_on": "2019/05/25/ 13:30:30",
            "state": "new",
            "status": "available",
            "price": "2500000.00",
            "manufacturer": "bmw",
            "model": "BMW 3 Series 320d 2017",
            "body_type": "car"
        },
        ...
    ],
    "success": true
}
````

#### Any background context you want to provide?
Create environment variables file i.e `.env` in the project root directory and include below variable
- `JWTPRIVATEKEY= yourjwtprivatekey`
- `CLOUD_NAME=cloudinary_name`
-  `API_ID=cloudinary_api_key`
- `API_SECRET=cloudinary_api_secret`

#### What are the relevant pivotal tracker stories?
- PT Story link - ( [166438826](https://www.pivotaltracker.com/story/show/166438826) )

#### Screenshots(if appropriate)
-N/A
